### PR TITLE
Remove automatic registration

### DIFF
--- a/Parse.podspec
+++ b/Parse.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name             = 'Parse'
-  s.version          = '1.14.2'
+  s.version          = '1.14.2.1'
   s.license          =  { :type => 'BSD', :file => 'LICENSE' }
   s.homepage         = 'https://www.parse.com/'
   s.summary          = 'A library that gives you access to the powerful Parse cloud platform from your iOS/OS X/watchOS/tvOS app.'
   s.authors          = 'Parse'
 
-  s.source           = { :git => "https://github.com/ParsePlatform/Parse-SDK-iOS-OSX.git", :tag => s.version.to_s }
+  s.source           = { :git => "https://github.com/LoungeBuddy/Parse-SDK-iOS-OSX.git", :tag => s.version.to_s }
 
   s.platform = :ios, :osx, :tvos, :watchos
   s.ios.deployment_target = '7.0'

--- a/Parse.xcodeproj/project.pbxproj
+++ b/Parse.xcodeproj/project.pbxproj
@@ -8639,6 +8639,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F55ABB591B4F39DA00A0ECD5 /* ParseUnitTests-iOS.xcconfig */;
 			buildSettings = {
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -8646,6 +8647,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F55ABB591B4F39DA00A0ECD5 /* ParseUnitTests-iOS.xcconfig */;
 			buildSettings = {
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -8653,6 +8655,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F55ABB5A1B4F39DA00A0ECD5 /* ParseUnitTests-macOS.xcconfig */;
 			buildSettings = {
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -8660,6 +8663,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F55ABB5A1B4F39DA00A0ECD5 /* ParseUnitTests-macOS.xcconfig */;
 			buildSettings = {
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Parse/Internal/Object/Subclassing/PFObjectSubclassingController.h
+++ b/Parse/Internal/Object/Subclassing/PFObjectSubclassingController.h
@@ -18,8 +18,6 @@
 #pragma mark - Registration
 ///--------------------------------------
 
-- (void)scanForUnregisteredSubclasses:(BOOL)shouldSubscribe;
-
 - (Class<PFSubclassing>)subclassForParseClassName:(NSString *)parseClassName;
 - (void)registerSubclass:(Class<PFSubclassing>)kls;
 - (void)unregisterSubclass:(Class<PFSubclassing>)kls;

--- a/Parse/Internal/PFCoreManager.m
+++ b/Parse/Internal/PFCoreManager.m
@@ -245,7 +245,6 @@
     dispatch_sync(_controllerAccessQueue, ^{
         if (!_objectSubclassingController) {
             _objectSubclassingController = [[PFObjectSubclassingController alloc] init];
-            [_objectSubclassingController scanForUnregisteredSubclasses:YES];
         }
         controller = _objectSubclassingController;
     });

--- a/Parse/PFObject+Subclass.h
+++ b/Parse/PFObject+Subclass.h
@@ -132,15 +132,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-/*!
- This protocol exists ONLY so that, if you absolutely need it, you can perform manual subclass registration
- via `[Subclass registerSubclass]`. Note that any calls to `registerSubclass` must happen after parse has been
- initialized already. This should only ever be needed in the scenario where you may be dynamically creation new 
- Objective-C classes for parse objects, or you are doing conditional subclass registration (e.g. only register class A 
- if config setting 'foo' is defined, otherwise register B).
- */
-@protocol PFSubclassingSkipAutomaticRegistration <PFSubclassing>
-
-@end
-
 NS_ASSUME_NONNULL_END

--- a/Parse/Parse.m
+++ b/Parse/Parse.m
@@ -80,6 +80,22 @@ static ParseClientConfiguration *currentParseConfiguration_;
 
     currentParseManager_ = manager;
 
+    PFObjectSubclassingController *subclassingController = [PFObject subclassingController];
+    // Register built-in subclasses of PFObject so they get used.
+    // We're forced to register subclasses directly this way, in order to prevent a deadlock.
+    // If we ever switch to bundle scanning, this code can go away.
+    [subclassingController registerSubclass:[PFUser class]];
+    [subclassingController registerSubclass:[PFSession class]];
+    [subclassingController registerSubclass:[PFRole class]];
+    [subclassingController registerSubclass:[PFPin class]];
+    [subclassingController registerSubclass:[PFEventuallyPin class]];
+#if !TARGET_OS_WATCH && !TARGET_OS_TV
+    [subclassingController registerSubclass:[PFInstallation class]];
+#endif
+#if TARGET_OS_IOS || TARGET_OS_TV
+    [subclassingController registerSubclass:[PFProduct class]];
+#endif
+
 #if TARGET_OS_IOS
     [PFNetworkActivityIndicatorManager sharedManager].enabled = YES;
 #endif

--- a/Tests/Other/Swift/SwiftSubclass.swift
+++ b/Tests/Other/Swift/SwiftSubclass.swift
@@ -12,11 +12,11 @@ import Foundation
 import Parse
 
 @objc
-public class SwiftSubclass: PFObject, PFSubclassing {
+open class SwiftSubclass: PFObject, PFSubclassing {
     @NSManaged public var primitiveProperty: Int
     @NSManaged public var objectProperty: AnyObject?
 
-    @NSManaged public var relationProperty: PFRelation?
+    @NSManaged public var relationProperty: PFRelation<PFObject>?
     @NSManaged public var badProperty: CGPoint
 
     public static func parseClassName() -> String {

--- a/Tests/Other/TestCases/UnitTestCase/PFUnitTestCase.m
+++ b/Tests/Other/TestCases/UnitTestCase/PFUnitTestCase.m
@@ -11,6 +11,7 @@
 
 #import "PFObjectSubclassingController.h"
 #import "Parse_Private.h"
+#import "PFCoreManager.h"
 
 @interface PFUnitTestCase ()
 
@@ -42,6 +43,7 @@
 - (void)tearDown {
     [[Parse _currentManager] clearEventuallyQueue];
     [Parse _clearCurrentManager];
+    [Parse _currentManager].coreManager.objectSubclassingController = nil;
 
     [super tearDown];
 }

--- a/Tests/Unit/ACLTests.m
+++ b/Tests/Unit/ACLTests.m
@@ -210,6 +210,8 @@
 
 
 - (void)testACLRequiresObjectId {
+    [PFUser registerSubclass];
+
     PFACL *acl = [PFACL ACL];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"

--- a/Tests/Unit/ObjectSubclassPropertiesTests.m
+++ b/Tests/Unit/ObjectSubclassPropertiesTests.m
@@ -106,6 +106,22 @@
 @implementation ObjectSubclassPropertiesTests
 
 ///--------------------------------------
+#pragma mark XCTestCase
+///--------------------------------------
+
+- (void)setUp {
+    [super setUp];
+
+    [PFTestObject registerSubclass];
+}
+
+- (void)tearDown {
+    [PFObject unregisterSubclass:[PFTestObject class]];
+
+    [super tearDown];
+}
+
+///--------------------------------------
 #pragma mark - Tests
 ///--------------------------------------
 

--- a/Tests/Unit/ObjectSubclassTests.m
+++ b/Tests/Unit/ObjectSubclassTests.m
@@ -17,7 +17,7 @@
 #pragma mark - Helpers
 ///--------------------------------------
 
-@interface TheFlash : PFObject<PFSubclassingSkipAutomaticRegistration> {
+@interface TheFlash : PFObject<PFSubclassing> {
     NSString *flashName;
 }
 
@@ -59,7 +59,7 @@
 
 @end
 
-@interface ClassWithDirtyingConstructor : PFObject<PFSubclassingSkipAutomaticRegistration>
+@interface ClassWithDirtyingConstructor : PFObject<PFSubclassing>
 @end
 
 @implementation ClassWithDirtyingConstructor
@@ -85,7 +85,7 @@
 @implementation UtilityClass
 @end
 
-@interface DescendantOfUtility : UtilityClass<PFSubclassingSkipAutomaticRegistration>
+@interface DescendantOfUtility : UtilityClass<PFSubclassing>
 @end
 
 @implementation DescendantOfUtility
@@ -94,7 +94,7 @@
 }
 @end
 
-@interface StateClass : PFObject<PFSubclassing, PFSubclassingSkipAutomaticRegistration>
+@interface StateClass : PFObject<PFSubclassing>
 
 @property (nonatomic, copy) NSString *state;
 
@@ -119,6 +119,17 @@
 @end
 
 @implementation ObjectSubclassTests
+
+///--------------------------------------
+#pragma mark XCTestCase
+///--------------------------------------
+
+- (void)tearDown {
+    [PFObject unregisterSubclass:[TheFlash class]];
+    [PFObject unregisterSubclass:[BarryAllen class]];
+
+    [super tearDown];
+}
 
 ///--------------------------------------
 #pragma mark - Tests
@@ -161,6 +172,18 @@
     // did not define parseClassName
     [DescendantOfUtility registerSubclass];
 }
+
+- (void)testSubclassRegistrationBeforeInitializingParse {
+    [[Parse _currentManager] clearEventuallyQueue];
+    [Parse _clearCurrentManager];
+
+    [TheFlash registerSubclass];
+
+    [Parse setApplicationId:@"a" clientKey:@"b"];
+
+    PFObject *theFlash = [PFObject objectWithClassName:@"Person"];
+    PFAssertIsKindOfClass(theFlash, [TheFlash class]);
+}		
 
 - (void)testStateIsSubclassable {
     [StateClass registerSubclass];

--- a/Tests/Unit/ObjectSubclassingControllerTests.m
+++ b/Tests/Unit/ObjectSubclassingControllerTests.m
@@ -16,13 +16,13 @@
 #import "PFUnitTestCase.h"
 #import "ParseUnitTests-Swift.h"
 
-@interface TestSubclass : PFObject<PFSubclassingSkipAutomaticRegistration>
+@interface TestSubclass : PFObject<PFSubclassing>
 @end
 
-@interface NotSubclass : PFObject<PFSubclassingSkipAutomaticRegistration>
+@interface NotSubclass : PFObject<PFSubclassing>
 @end
 
-@interface PropertySubclass : PFObject<PFSubclassingSkipAutomaticRegistration> {
+@interface PropertySubclass : PFObject<PFSubclassing> {
 @public
     id _ivarProperty;
 }

--- a/Tests/Unit/OfflineQueryLogicUnitTests.m
+++ b/Tests/Unit/OfflineQueryLogicUnitTests.m
@@ -29,10 +29,12 @@
 - (void)setUp {
     [super setUp];
 
+    [PFUser registerSubclass];
     _user = [PFUser user];
 }
 
 - (void)tearDown {
+    [PFObject unregisterSubclass:[PFUser class]];
     _user = nil;
 
     [super tearDown];

--- a/Tests/Unit/PinUnitTests.m
+++ b/Tests/Unit/PinUnitTests.m
@@ -18,6 +18,24 @@
 @implementation PinUnitTests
 
 ///--------------------------------------
+#pragma mark XCTestCase
+///--------------------------------------
+
+- (void)setUp {
+    [super setUp];
+
+    [Parse enableLocalDatastore];
+    [Parse setApplicationId:@"a" clientKey:@"b"];
+}
+
+- (void)tearDown {
+    [[Parse _currentManager] clearEventuallyQueue];
+    [Parse _clearCurrentManager];
+
+    [super tearDown];
+}
+
+///--------------------------------------
 #pragma mark - Tests
 ///--------------------------------------
 

--- a/Tests/Unit/SessionControllerTests.m
+++ b/Tests/Unit/SessionControllerTests.m
@@ -26,6 +26,22 @@
 @implementation SessionControllerTests
 
 ///--------------------------------------
+#pragma mark XCTestCase
+///--------------------------------------
+
+- (void)setUp {
+    [super setUp];
+
+    [PFSession registerSubclass];
+}
+
+- (void)tearDown {
+    [PFObject unregisterSubclass:[PFSession class]];
+
+    [super tearDown];
+}
+
+///--------------------------------------
 #pragma mark - Helpers
 ///--------------------------------------
 

--- a/Tests/Unit/SessionUnitTests.m
+++ b/Tests/Unit/SessionUnitTests.m
@@ -44,12 +44,24 @@
 #pragma mark - Tests
 ///--------------------------------------
 
+- (void)testSessionClassIsRegistered {
+    [[Parse _currentManager] clearEventuallyQueue];
+    [Parse _clearCurrentManager];
+    [Parse _currentManager].coreManager.objectSubclassingController = nil;
+
+    [PFObject unregisterSubclass:[PFSession class]];
+    [Parse setApplicationId:@"a" clientKey:@"b"];
+    XCTAssertNotNil([PFSession query]);
+}
+
 - (void)testConstructorsClassNameValidation {
     PFAssertThrowsInvalidArgumentException([[PFSession alloc] initWithClassName:@"yarrclass"],
                                            @"Should throw an exception for invalid classname");
 }
 
 - (void)testSessionImmutableFieldsCannotBeChanged {
+    [PFSession registerSubclass];
+
     PFSession *session = [PFSession object];
     session[@"yolo"] = @"El Capitan!"; // Test for regular mutability
     PFAssertThrowsInvalidArgumentException(session[@"sessionToken"] = @"a");
@@ -61,6 +73,8 @@
 }
 
 - (void)testSessionImmutableFieldsCannotBeDeleted {
+    [PFSession registerSubclass];
+
     PFSession *session = [PFSession object];
 
     [session removeObjectForKey:@"yolo"];// Test for regular mutability

--- a/Tests/Unit/UserUnitTests.m
+++ b/Tests/Unit/UserUnitTests.m
@@ -25,11 +25,15 @@
 }
 
 - (void)testImmutableFieldsCannotBeChanged {
+    [PFUser registerSubclass];
+
     PFUser *user = [PFUser object];
     PFAssertThrowsInvalidArgumentException(user[@"sessionToken"] = @"a");
 }
 
 - (void)testImmutableFieldsCannotBeDeleted {
+    [PFUser registerSubclass];
+
     PFUser *user = [PFUser object];
     PFAssertThrowsInvalidArgumentException([user removeObjectForKey:@"username"]);
     PFAssertThrowsInvalidArgumentException([user removeObjectForKey:@"sessionToken"]);


### PR DESCRIPTION
This effectively reverts e9a4e59 to remove automatic subclass registration.

For unknown reasons, this is broken on iOS 10 for a large number of people. Could spend the time debugging this, but, could also keep on keeping on with existing code that uses manual registration that isn't crashing ¯_(ツ)_/¯

ref: https://www.fabric.io/loungebuddy/ios/apps/com.loungebuddy.appstore/issues/57b6a3ddffcdc04250e86055
