### PR TITLE
add support for adding and removing listeners that are applied to all new PFObject's

### DIFF
--- a/Parse.podspec
+++ b/Parse.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Parse'
-  s.version          = '1.14.2.1'
+  s.version          = '1.14.2.2'
   s.license          =  { :type => 'BSD', :file => 'LICENSE' }
   s.homepage         = 'https://www.parse.com/'
   s.summary          = 'A library that gives you access to the powerful Parse cloud platform from your iOS/OS X/watchOS/tvOS app.'

--- a/Parse/Internal/Object/PFObjectPrivate.h
+++ b/Parse/Internal/Object/PFObjectPrivate.h
@@ -276,8 +276,12 @@
 - (NSString *)displayClassName;
 - (NSString *)displayObjectId;
 
-- (void)registerSaveListener:(void (^)(id result, NSError *error))callback;
-- (void)unregisterSaveListener:(void (^)(id result, NSError *error))callback;
+typedef PFMulticastDelegateCallback _PFSaveListenerCallback;
+@property (nonatomic, class, readonly) NSMutableDictionary <NSUUID *, _PFSaveListenerCallback> *globalSaveListeners;
++ (id)registerGlobalSaveListener:(_PFSaveListenerCallback)callback;
++ (void)unregisterGlobalSaveListener:(id)listener;
+- (void)registerSaveListener:(_PFSaveListenerCallback)callback;
+- (void)unregisterSaveListener:(_PFSaveListenerCallback)callback;
 - (PFACL *)ACLWithoutCopying;
 
 ///--------------------------------------

--- a/Parse/Internal/PFMulticastDelegate.h
+++ b/Parse/Internal/PFMulticastDelegate.h
@@ -9,6 +9,8 @@
 
 #import <Foundation/Foundation.h>
 
+typedef void (^PFMulticastDelegateCallback)(id result, NSError *error);
+
 /**
  Represents an event that can be subscribed to by multiple observers.
  */
@@ -20,8 +22,8 @@
  Important: if you ever plan to be able to unsubscribe the block, you must copy the block
  before passing it to subscribe, and use the same instance for unsubscribe.
  */
-- (void)subscribe:(void(^)(id result, NSError *error))block;
-- (void)unsubscribe:(void(^)(id result, NSError *error))block;
+- (void)subscribe:(PFMulticastDelegateCallback)block;
+- (void)unsubscribe:(PFMulticastDelegateCallback)block;
 - (void)invoke:(id)result error:(NSError *)error;
 - (void)clear;
 

--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -1424,7 +1424,11 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     return [[controller getCurrentUserSessionTokenAsync] continueWithBlock:^id(BFTask *task) {
         NSString *sessionToken = task.result;
         return [toAwait continueAsyncWithBlock:^id(BFTask *task) {
-            return [[[self class] objectController] deleteObjectAsync:self withSessionToken:sessionToken];
+            return [[[[self class] objectController] deleteObjectAsync:self withSessionToken:sessionToken] continueWithBlock:^(BFTask *task) {
+                id result = task.result;
+                [self.saveDelegate invoke:result error:task.error];
+                return task;
+            }];
         }];
     }];
 }
@@ -1885,7 +1889,11 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 
 - (BFTask *)saveInBackground {
     return [self.taskQueue enqueue:^BFTask *(BFTask *toAwait) {
-        return [self saveAsync:toAwait];
+        return [[self saveAsync:toAwait] continueWithBlock:^(BFTask *task) {
+            id result = task.result;
+            [self.saveDelegate invoke:result error:task.error];
+            return result;
+        }];
     }];
 }
 
@@ -1895,9 +1903,11 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 
 - (BFTask *)saveEventually {
     return [[self _enqueueSaveEventuallyWithChildren:YES] continueWithSuccessBlock:^id(BFTask *task) {
+        id result = task.result;
+        [self.saveDelegate invoke:result error:task.error];
         // The result of the previous task will be an instance of BFTask.
         // Returning it here will trigger the whole task stack become an actual save task.
-        return task.result;
+        return result;
     }];
 }
 
@@ -1909,6 +1919,8 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     return [[[_eventuallyTaskQueue enqueue:^BFTask *(BFTask *toAwait) {
         NSString *sessionToken = [PFUser currentSessionToken];
         return [[toAwait continueAsyncWithBlock:^id(BFTask *task) {
+            id result = task.result;
+            [self.saveDelegate invoke:result error:task.error];
             return [self _validateDeleteAsync];
         }] continueWithSuccessBlock:^id(BFTask *task) {
             @synchronized (lock) {


### PR DESCRIPTION
A listener is basically the subscriber part of pubsub, where the publisher is a `PFObject`.

Parse already supported this on a per-object basis, so all 240acff651726ed39aca09c8fdf462015e2db731 had to do was add some new SPI to do this on a global basis (which will automatically start to listen in on any new object in `init`).

To give listeners some more useful events, 6b1be935970297c88a208c671556e1a335ac2a4e started publishing in a few more completion blocks, to cover all forms of saving and deleting objects.

The change is a lil larger than strictly needed, since I changed `PFMulticastDelegate` to be threadsafe + keep a strong reference to a copy of any subscriber block, rather than retaining the block.
